### PR TITLE
Remove worker pool ID from tags and VMSS name

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -138,6 +138,6 @@ variable "perform_unattended_upgrade_on_boot" {
   default     = true
 }
 
-locals {
-  namespace = "${var.name_prefix}-${var.worker_pool_id}"
-}
+# locals {
+#   namespace = "${var.name_prefix}-${var.worker_pool_id}"
+# }

--- a/vmss.tf
+++ b/vmss.tf
@@ -103,7 +103,7 @@ chmod 744 /var/lib/cloud/scripts/per-boot/spacelift-boot.sh
 }
 
 resource "azurerm_linux_virtual_machine_scale_set" "this" {
-  name                = local.namespace
+  name                = var.name_prefix
   resource_group_name = var.resource_group.name
   location            = var.resource_group.location
   sku                 = var.vmss_sku

--- a/vmss.tf
+++ b/vmss.tf
@@ -175,9 +175,5 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
     rule = "OldestVM"
   }
 
-  tags = merge(var.tags,
-    {
-      WorkerPoolID : var.worker_pool_id
-    }
-  )
+  tags = var.tags
 }


### PR DESCRIPTION
Created very long VMSS names, and known-after-apply conflicted with OPA tagging policy.